### PR TITLE
Fix root owned files in target dir after running tests

### DIFF
--- a/src/main/java/org/testcontainers/containers/TarantoolCartridgeContainer.java
+++ b/src/main/java/org/testcontainers/containers/TarantoolCartridgeContainer.java
@@ -159,6 +159,8 @@ public class TarantoolCartridgeContainer extends TarantoolContainer {
                 .run("/bin/sh", "-c",
                         "curl -L https://tarantool.io/installer.sh | VER=2.4 /bin/bash -s -- --repo-only && " +
                                 "yum -y install cmake make gcc git cartridge-cli && cartridge version")
+                .user(String.format("%s:%s", TARANTOOL_SERVER_USER, TARANTOOL_SERVER_GROUP))
+                .cmd("cartridge build && cartridge start")
                 .build();
     }
 
@@ -329,7 +331,6 @@ public class TarantoolCartridgeContainer extends TarantoolContainer {
         withPassword(getRouterPassword());
         withEnv("BOOTSTRAP", "ON");
         withWorkingDirectory(getInstanceDir());
-        withCommand("/bin/sh", "-c", "cartridge build && cartridge start");
     }
 
     @Override

--- a/src/main/java/org/testcontainers/containers/TarantoolContainer.java
+++ b/src/main/java/org/testcontainers/containers/TarantoolContainer.java
@@ -33,6 +33,8 @@ import java.util.stream.Stream;
  */
 public class TarantoolContainer extends GenericContainer<TarantoolContainer> {
 
+    public static final String TARANTOOL_SERVER_USER = "tarantool";
+    public static final String TARANTOOL_SERVER_GROUP = "tarantool";
     public static final String TARANTOOL_IMAGE = "tarantool/tarantool";
     public static final String DEFAULT_IMAGE_VERSION = "2.x-centos7";
     public static final String DEFAULT_TARANTOOL_BASE_IMAGE =
@@ -48,6 +50,7 @@ public class TarantoolContainer extends GenericContainer<TarantoolContainer> {
     private static final String SCRIPT_FILENAME = "server.lua";
 
     private static final String INSTANCE_DIR = "/app";
+    private static final String TMP_DIR = "/tmp";
 
     private String username = API_USER;
     private String password = API_PASSWORD;
@@ -274,6 +277,7 @@ public class TarantoolContainer extends GenericContainer<TarantoolContainer> {
     protected void configure() {
         withFileSystemBind(directoryResourcePath, instanceDir, BindMode.READ_WRITE);
         withExposedPorts(port);
+
         withCommand("tarantool",
                 Paths.get(instanceDir, scriptFileName).toString().replace('\\','/'));
 
@@ -332,9 +336,8 @@ public class TarantoolContainer extends GenericContainer<TarantoolContainer> {
             throw new IllegalStateException("Cannot execute scripts in stopped container");
         }
         String scriptName = Paths.get(scriptResourcePath).getFileName().toString();
-        String containerPath = Paths.get(INSTANCE_DIR, scriptName).toString().replace('\\','/');
-        this.copyFileToContainer(
-                MountableFile.forClasspathResource(scriptResourcePath), containerPath);
+        String containerPath = Paths.get(TMP_DIR, scriptName).toString().replace('\\','/');
+        this.copyFileToContainer(MountableFile.forClasspathResource(scriptResourcePath), containerPath);
         return executeCommand(String.format("dofile('%s')", containerPath));
     }
 


### PR DESCRIPTION
Fixes issue with docker daemon running under root (reproduces on Ubuntu / WSL).
https://github.com/tarantool/cartridge-java/issues/24

Fix description:
1) TarantoolContainer.executeScript() now copies script to /tmp directory instead of INSTANCE_DIR. When INSTANCE_DIR was mounted as docker volume - it's unable to change owner of the copied file via testcontainer API. Now file is not copied to host volume.

2) TarantoolCartridgeContainer now builds image with forcing 'tarantool' user for container start command. Command moved from configuration() to CMD Dockerfile section. It's unable to specify user with testcontainers API in configuration phase.
So now tarantool instances that are started via cartridge cli are run under correct user.
