### PR TITLE
Refactor to using a Dockerfile instead of runtime-built image 

### DIFF
--- a/.github/workflows/ubuntu-master.yml
+++ b/.github/workflows/ubuntu-master.yml
@@ -27,4 +27,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build with Maven
-        run: mvn -B verify --file pom.xml -DdockerfileUseRoot=true
+        env:
+          TARANTOOL_SERVER_USER: root
+          TARANTOOL_SERVER_GROUP: root
+        run: mvn -B verify --file pom.xml

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the Maven dependency:
 <dependency>
   <groupId>io.tarantool</groupId>
   <artifactId>testcontainers-java-tarantool</artifactId>
-  <version>0.2.3</version>
+  <version>0.3.0</version>
 </dependency>
 ```
 
@@ -49,7 +49,7 @@ Instantiate a generic TarantoolContainer and use it in your tests:
 public class SomeTest {
 
     @ClassRule
-    static TarantoolContainer container = new TarantoolContainer();
+    static TarantoolContainer<?> container = new TarantoolContainer<>();
 
     @BeforeAll
     public void setUp() {
@@ -171,9 +171,9 @@ Now we can set up a Cartridge container for tests:
 public class SomeOtherTest {
 
     @Container
-    private static final TarantoolCartridgeContainer container =
+    private static final TarantoolCartridgeContainer<?> container =
         // Pass the classpath-relative paths of the instances configuration and topology script files
-        new TarantoolCartridgeContainer("cartridge/instances.yml", "cartridge/topology.lua")
+        new TarantoolCartridgeContainer<>("cartridge/instances.yml", "cartridge/topology.lua")
             // Point out the classpath-relative directory where the application files reside
             .withDirectoryBinding("cartridge")
             .withRouterHost("localhost") // Optional, "localhost" is default

--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
   </scm>
 
     <properties>
-        <driver.version>0.1.1</driver.version>
-        <testcontainers.version>1.15.0-rc2</testcontainers.version>
+        <driver.version>0.3.3</driver.version>
+        <testcontainers.version>1.15.1</testcontainers.version>
         <snakeyaml.version>1.26</snakeyaml.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -63,7 +63,7 @@
         </dependency>
         <dependency>
             <groupId>io.tarantool</groupId>
-            <artifactId>driver</artifactId>
+            <artifactId>cartridge-driver</artifactId>
             <version>${driver.version}</version>
         </dependency>
         <dependency>

--- a/src/main/java/org/testcontainers/containers/TarantoolCartridgeContainer.java
+++ b/src/main/java/org/testcontainers/containers/TarantoolCartridgeContainer.java
@@ -114,7 +114,7 @@ public class TarantoolCartridgeContainer extends GenericContainer<TarantoolCartr
      * @param topologyConfigurationFile path to a topology bootstrap script, relative to the classpath resources
      */
     public TarantoolCartridgeContainer(String instancesFile, String topologyConfigurationFile) {
-        this(buildImage(), instancesFile, topologyConfigurationFile);
+        this(withArguments(buildImage()), instancesFile, topologyConfigurationFile);
     }
 
     /**
@@ -125,7 +125,7 @@ public class TarantoolCartridgeContainer extends GenericContainer<TarantoolCartr
      * @param topologyConfigurationFile path to a topology bootstrap script, relative to the classpath resources
      */
     public TarantoolCartridgeContainer(String dockerFile, String instancesFile, String topologyConfigurationFile) {
-        this(buildImage(dockerFile), instancesFile, topologyConfigurationFile);
+        this(withArguments(buildImage(dockerFile)), instancesFile, topologyConfigurationFile);
     }
 
     /**
@@ -140,7 +140,7 @@ public class TarantoolCartridgeContainer extends GenericContainer<TarantoolCartr
      */
     public TarantoolCartridgeContainer(String dockerFile, String buildImageName,
                                        String instancesFile, String topologyConfigurationFile) {
-        this(buildImage(dockerFile, buildImageName), instancesFile, topologyConfigurationFile);
+        this(withArguments(buildImage(dockerFile, buildImageName)), instancesFile, topologyConfigurationFile);
     }
 
     private TarantoolCartridgeContainer(Future<String> image, String instancesFile, String topologyConfigurationFile) {
@@ -154,15 +154,25 @@ public class TarantoolCartridgeContainer extends GenericContainer<TarantoolCartr
         this.clientHelper = new TarantoolContainerClientHelper(this);
     }
 
-    private static Future<String> buildImage() {
+    private static Future<String> withArguments(ImageFromDockerfile image) {
+        return image
+            .withBuildArg(ENV_TARANTOOL_VERSION, System.getenv(ENV_TARANTOOL_VERSION))
+            .withBuildArg(ENV_TARANTOOL_SERVER_USER, System.getenv(ENV_TARANTOOL_SERVER_USER))
+            .withBuildArg(ENV_TARANTOOL_SERVER_UID, System.getenv(ENV_TARANTOOL_SERVER_UID))
+            .withBuildArg(ENV_TARANTOOL_SERVER_GROUP, System.getenv(ENV_TARANTOOL_SERVER_GROUP))
+            .withBuildArg(ENV_TARANTOOL_SERVER_GID, System.getenv(ENV_TARANTOOL_SERVER_GID))
+            .withBuildArg(ENV_TARANTOOL_WORKDIR, System.getenv(ENV_TARANTOOL_WORKDIR));
+    }
+
+    private static ImageFromDockerfile buildImage() {
         return buildImage(DOCKERFILE);
     }
 
-    private static Future<String> buildImage(String dockerFile) {
+    private static ImageFromDockerfile buildImage(String dockerFile) {
         return new ImageFromDockerfile().withFileFromClasspath("Dockerfile", dockerFile);
     }
 
-    private static Future<String> buildImage(String dockerFile, String buildImageName) {
+    private static ImageFromDockerfile buildImage(String dockerFile, String buildImageName) {
         return new ImageFromDockerfile(buildImageName, false)
                 .withFileFromClasspath("Dockerfile", dockerFile);
     }
@@ -355,12 +365,6 @@ public class TarantoolCartridgeContainer extends GenericContainer<TarantoolCartr
     protected void configure() {
         withFileSystemBind(getDirectoryBinding(), getInstanceDir(), BindMode.READ_WRITE);
         withExposedPorts(instanceFileParser.getExposablePorts());
-        withEnv(ENV_TARANTOOL_VERSION, System.getenv(ENV_TARANTOOL_VERSION));
-        withEnv(ENV_TARANTOOL_SERVER_USER, System.getenv(ENV_TARANTOOL_SERVER_USER));
-        withEnv(ENV_TARANTOOL_SERVER_UID, System.getenv(ENV_TARANTOOL_SERVER_UID));
-        withEnv(ENV_TARANTOOL_SERVER_GROUP, System.getenv(ENV_TARANTOOL_SERVER_GROUP));
-        withEnv(ENV_TARANTOOL_SERVER_GID, System.getenv(ENV_TARANTOOL_SERVER_GID));
-        withEnv(ENV_TARANTOOL_WORKDIR, System.getenv(ENV_TARANTOOL_WORKDIR));
     }
 
     @Override

--- a/src/main/java/org/testcontainers/containers/TarantoolCartridgeContainer.java
+++ b/src/main/java/org/testcontainers/containers/TarantoolCartridgeContainer.java
@@ -4,8 +4,6 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
 import java.net.URL;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -88,6 +86,13 @@ public class TarantoolCartridgeContainer extends GenericContainer<TarantoolCartr
     private static final String VSHARD_BOOTSTRAP_COMMAND = "return require('cartridge').admin_bootstrap_vshard()";
     private static final String SCRIPT_RESOURCE_DIRECTORY = "";
     private static final String INSTANCE_DIR = "/app";
+
+    private static final String ENV_TARANTOOL_VERSION="TARANTOOL_VERSION";
+    private static final String ENV_TARANTOOL_SERVER_USER="TARANTOOL_SERVER_USER";
+    private static final String ENV_TARANTOOL_SERVER_UID="TARANTOOL_SERVER_UID";
+    private static final String ENV_TARANTOOL_SERVER_GROUP="TARANTOOL_SERVER_GROUP";
+    private static final String ENV_TARANTOOL_SERVER_GID="TARANTOOL_SERVER_GID";
+    private static final String ENV_TARANTOOL_WORKDIR="TARANTOOL_WORKDIR";
 
     private String routerHost = ROUTER_HOST;
     private int routerPort = ROUTER_PORT;
@@ -350,6 +355,12 @@ public class TarantoolCartridgeContainer extends GenericContainer<TarantoolCartr
     protected void configure() {
         withFileSystemBind(getDirectoryBinding(), getInstanceDir(), BindMode.READ_WRITE);
         withExposedPorts(instanceFileParser.getExposablePorts());
+        withEnv(ENV_TARANTOOL_VERSION, System.getenv(ENV_TARANTOOL_VERSION));
+        withEnv(ENV_TARANTOOL_SERVER_USER, System.getenv(ENV_TARANTOOL_SERVER_USER));
+        withEnv(ENV_TARANTOOL_SERVER_UID, System.getenv(ENV_TARANTOOL_SERVER_UID));
+        withEnv(ENV_TARANTOOL_SERVER_GROUP, System.getenv(ENV_TARANTOOL_SERVER_GROUP));
+        withEnv(ENV_TARANTOOL_SERVER_GID, System.getenv(ENV_TARANTOOL_SERVER_GID));
+        withEnv(ENV_TARANTOOL_WORKDIR, System.getenv(ENV_TARANTOOL_WORKDIR));
     }
 
     @Override

--- a/src/main/java/org/testcontainers/containers/TarantoolCartridgeContainer.java
+++ b/src/main/java/org/testcontainers/containers/TarantoolCartridgeContainer.java
@@ -77,7 +77,8 @@ import java.util.concurrent.TimeoutException;
  *
  * @author Alexey Kuzin
  */
-public class TarantoolCartridgeContainer extends TarantoolContainer {
+public class TarantoolCartridgeContainer<SELF extends TarantoolCartridgeContainer<SELF>>
+        extends TarantoolContainer<SELF> implements Container<SELF> {
 
     private static final String ROUTER_HOST = "localhost";
     private static final int ROUTER_PORT = 3301;
@@ -243,7 +244,7 @@ public class TarantoolCartridgeContainer extends TarantoolContainer {
     }
 
     @Override
-    public TarantoolCartridgeContainer withDirectoryBinding(String directoryResourcePath) {
+    public TarantoolCartridgeContainer<SELF> withDirectoryBinding(String directoryResourcePath) {
         super.withDirectoryBinding(directoryResourcePath);
         return this;
     }
@@ -263,7 +264,7 @@ public class TarantoolCartridgeContainer extends TarantoolContainer {
      * @param routerHost a hostname, default is "localhost"
      * @return this container instance
      */
-    public TarantoolCartridgeContainer withRouterHost(String routerHost) {
+    public TarantoolCartridgeContainer<SELF> withRouterHost(String routerHost) {
         checkNotRunning();
         this.routerHost = routerHost;
         return this;
@@ -275,7 +276,7 @@ public class TarantoolCartridgeContainer extends TarantoolContainer {
      * @param routerPort router Tarantool node port, usually 3301
      * @return this container instance
      */
-    public TarantoolCartridgeContainer withRouterPort(int routerPort) {
+    public TarantoolCartridgeContainer<SELF> withRouterPort(int routerPort) {
         checkNotRunning();
         this.routerPort = routerPort;
         return this;
@@ -287,7 +288,7 @@ public class TarantoolCartridgeContainer extends TarantoolContainer {
      * @param apiPort HTTP API port, usually 8081
      * @return this container instance
      */
-    public TarantoolCartridgeContainer withAPIPort(int apiPort) {
+    public TarantoolCartridgeContainer<SELF> withAPIPort(int apiPort) {
         checkNotRunning();
         this.apiPort = apiPort;
         return this;
@@ -299,7 +300,7 @@ public class TarantoolCartridgeContainer extends TarantoolContainer {
      * @param routerUsername a user name, default is "admin"
      * @return this container instance
      */
-    public TarantoolCartridgeContainer withRouterUsername(String routerUsername) {
+    public TarantoolCartridgeContainer<SELF> withRouterUsername(String routerUsername) {
         checkNotRunning();
         this.routerUsername = routerUsername;
         return this;
@@ -311,20 +312,20 @@ public class TarantoolCartridgeContainer extends TarantoolContainer {
      * @param routerPassword a user password, usually is a value of the "cluster_cookie" option in cartridge.cfg({...})
      * @return this container instance
      */
-    public TarantoolCartridgeContainer withRouterPassword(String routerPassword) {
+    public TarantoolCartridgeContainer<SELF> withRouterPassword(String routerPassword) {
         checkNotRunning();
         this.routerPassword = routerPassword;
         return this;
     }
 
     @Override
-    public TarantoolCartridgeContainer withLogLevel(TarantoolLogLevel logLevel) {
+    public TarantoolCartridgeContainer<SELF> withLogLevel(TarantoolLogLevel logLevel) {
         // not supported
         return this;
     }
 
     @Override
-    public TarantoolCartridgeContainer withMemtxMemory(Integer memtxMemory) {
+    public TarantoolCartridgeContainer<SELF> withMemtxMemory(Integer memtxMemory) {
         // not supported
         return this;
     }
@@ -373,13 +374,7 @@ public class TarantoolCartridgeContainer extends TarantoolContainer {
     }
 
     @Override
-    public TarantoolCartridgeContainer withReuse(boolean reusable) {
-        super.withReuse(reusable);
-        return this;
-    }
-
-    @Override
-    public TarantoolCartridgeContainer cleanUpDirectory(String directoryResourcePath) {
+    public TarantoolCartridgeContainer<SELF> cleanUpDirectory(String directoryResourcePath) {
         super.cleanUpDirectory(directoryResourcePath);
         return this;
     }

--- a/src/main/java/org/testcontainers/containers/TarantoolContainer.java
+++ b/src/main/java/org/testcontainers/containers/TarantoolContainer.java
@@ -31,7 +31,7 @@ import java.util.stream.Stream;
  *
  * @author Alexey Kuzin
  */
-public class TarantoolContainer extends GenericContainer<TarantoolContainer> {
+public class TarantoolContainer<SELF extends TarantoolContainer<SELF>> extends GenericContainer<SELF> {
 
     public static final String TARANTOOL_SERVER_USER = "tarantool";
     public static final String TARANTOOL_SERVER_GROUP = "tarantool";
@@ -58,7 +58,7 @@ public class TarantoolContainer extends GenericContainer<TarantoolContainer> {
     private Integer port = DEFAULT_PORT;
     private TarantoolLogLevel logLevel = LOG_LEVEL;
     private Integer memtxMemory = MEMTX_MEMORY;
-    private String directoryResourcePath = getClass().getClassLoader().getResource(SCRIPT_RESOURCE_DIRECTORY).getPath();
+    private String directoryResourcePath = SCRIPT_RESOURCE_DIRECTORY;
     private final List<String> cleanupDirectories = new LinkedList<>();
     private String scriptFileName = SCRIPT_FILENAME;
     private final String instanceDir = INSTANCE_DIR;
@@ -206,8 +206,7 @@ public class TarantoolContainer extends GenericContainer<TarantoolContainer> {
      */
     public TarantoolContainer cleanUpDirectory(String directoryResourcePath) {
         if (directoryResourcePath == null) {
-            throw new IllegalArgumentException(
-                    String.format("No resource path found for the specified resource %s", directoryResourcePath));
+            throw new IllegalArgumentException("The specified cleanup directory is null");
         }
         this.cleanupDirectories.add(directoryResourcePath);
         return this;
@@ -331,7 +330,7 @@ public class TarantoolContainer extends GenericContainer<TarantoolContainer> {
      * @return script execution result
      * @throws Exception if failed to connect to the instance or execution fails
      */
-    public CompletableFuture<List<Object>> executeScript(String scriptResourcePath) throws Exception {
+    public CompletableFuture<List<?>> executeScript(String scriptResourcePath) throws Exception {
         if (!isRunning()) {
             throw new IllegalStateException("Cannot execute scripts in stopped container");
         }
@@ -349,7 +348,7 @@ public class TarantoolContainer extends GenericContainer<TarantoolContainer> {
      * @return command execution result
      * @throws Exception if failed to connect to the instance or execution fails
      */
-    public CompletableFuture<List<Object>> executeCommand(String command, Object... arguments) throws Exception {
+    public CompletableFuture<List<?>> executeCommand(String command, Object... arguments) throws Exception {
         if (!isRunning()) {
             throw new IllegalStateException("Cannot execute commands in stopped container");
         }

--- a/src/main/java/org/testcontainers/containers/TarantoolContainerClientHelper.java
+++ b/src/main/java/org/testcontainers/containers/TarantoolContainerClientHelper.java
@@ -1,0 +1,76 @@
+package org.testcontainers.containers;
+
+import io.tarantool.driver.StandaloneTarantoolClient;
+import io.tarantool.driver.TarantoolClientConfig;
+import io.tarantool.driver.TarantoolServerAddress;
+import io.tarantool.driver.api.TarantoolClient;
+import io.tarantool.driver.auth.SimpleTarantoolCredentials;
+import io.tarantool.driver.auth.TarantoolCredentials;
+import org.testcontainers.utility.MountableFile;
+
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Provides a wrapper around a Tarantool client with helper methods
+ *
+ * @author Alexey Kuzin
+ */
+public final class TarantoolContainerClientHelper {
+
+    private static final String TMP_DIR = "/tmp";
+
+    private final TarantoolContainerOperations<? extends Container<?>> container;
+    private final AtomicReference<TarantoolClient> clientHolder = new AtomicReference<>();
+
+    TarantoolContainerClientHelper(TarantoolContainerOperations<? extends Container<?>> container) {
+        this.container = container;
+    }
+
+    private TarantoolClient createClient(TarantoolClientConfig config, TarantoolServerAddress address) {
+        return new StandaloneTarantoolClient(config, address);
+    }
+
+    /**
+     * Configure or return an already configured client connected to a Cartridge router
+     *
+     * @param config router instance client config
+     * @param address router host address
+     * @return a configured client
+     */
+    public TarantoolClient getClient(TarantoolClientConfig config, TarantoolServerAddress address) {
+        if (!container.isRunning()) {
+            throw new IllegalStateException("Cannot connect to Tarantool instance in a stopped container");
+        }
+        if (clientHolder.get() == null) {
+            clientHolder.compareAndSet(null, createClient(config, address));
+        }
+        return clientHolder.get();
+    }
+
+    public CompletableFuture<List<?>> executeScript(String scriptResourcePath) throws Exception {
+        if (!container.isRunning()) {
+            throw new IllegalStateException("Cannot execute scripts in stopped container");
+        }
+
+        String scriptName = Paths.get(scriptResourcePath).getFileName().toString();
+        String containerPath = Paths.get(TMP_DIR, scriptName).toString().replace('\\','/');
+        container.copyFileToContainer(MountableFile.forClasspathResource(scriptResourcePath), containerPath);
+        return executeCommand(String.format("dofile('%s')", containerPath));
+    }
+
+    public CompletableFuture<List<?>> executeCommand(String command, Object... arguments) throws Exception {
+        if (!container.isRunning()) {
+            throw new IllegalStateException("Cannot execute commands in stopped container");
+        }
+
+        TarantoolCredentials credentials = new SimpleTarantoolCredentials(
+                container.getUsername(), container.getPassword());
+        TarantoolServerAddress address = new TarantoolServerAddress(container.getHost(), container.getPort());
+        TarantoolClientConfig config = TarantoolClientConfig.builder().withCredentials(credentials).build();
+        return getClient(config, address).eval(command, Arrays.asList(arguments));
+    }
+}

--- a/src/main/java/org/testcontainers/containers/TarantoolContainerOperations.java
+++ b/src/main/java/org/testcontainers/containers/TarantoolContainerOperations.java
@@ -1,0 +1,66 @@
+package org.testcontainers.containers;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Represents operations available on a Tarantool Container
+ *
+ * @author Alexey Kuzin
+ */
+public interface TarantoolContainerOperations<T extends Container<T>> extends Container<T> {
+    /**
+     * Get the Tarantool server exposed port for connecting the client to
+     *
+     * @return a port
+     */
+    int getPort();
+
+    /**
+     * Get the Tarantool user name for connecting the client with
+     *
+     * @return a user name
+     */
+    String getUsername();
+
+    /**
+     * Get the Tarantool user password for connecting the client with
+     *
+     * @return a user password
+     */
+    String getPassword();
+
+    /**
+     * Get the app scripts directory
+     *
+     * @return the app directory
+     */
+    String getDirectoryBinding();
+
+    /**
+     * Get the app scripts directory in the container
+     *
+     * @return the app scripts directory
+     */
+    String getInstanceDir();
+
+    /**
+     * Execute a local script in the Tarantool instance. The path must be classpath-relative.
+     * `dofile()` function is executed internally, so possible exceptions will be caught as the client exceptions.
+     *
+     * @param scriptResourcePath the classpath resource path to a script
+     * @return script execution result
+     * @throws Exception if failed to connect to the instance or execution fails
+     */
+    CompletableFuture<List<?>> executeScript(String scriptResourcePath) throws Exception;
+
+    /**
+     * Execute a command in the Tarantool instance. Example of a command: `return 1 + 2, 'foo'`
+     *
+     * @param command a valid Lua command or a sequence of Lua commands
+     * @param arguments command arguments
+     * @return command execution result
+     * @throws Exception if failed to connect to the instance or execution fails
+     */
+    CompletableFuture<List<?>> executeCommand(String command, Object... arguments) throws Exception;
+}

--- a/src/main/resources/Dockerfile
+++ b/src/main/resources/Dockerfile
@@ -1,9 +1,9 @@
 FROM centos:7 AS tarantool-base
-ENV TARANTOOL_VERSION=2.4
-ENV TARANTOOL_SERVER_USER="tarantool"
-ENV TARANTOOL_SERVER_UID=1000
-ENV TARANTOOL_SERVER_GROUP="tarantool"
-ENV TARANTOOL_SERVER_GID=1000
+ARG TARANTOOL_VERSION=2.4
+ARG TARANTOOL_SERVER_USER="tarantool"
+ARG TARANTOOL_SERVER_UID=1000
+ARG TARANTOOL_SERVER_GROUP="tarantool"
+ARG TARANTOOL_SERVER_GID=1000
 RUN curl -L https://tarantool.io/installer.sh | VER=$TARANTOOL_VERSION /bin/bash -s -- --repo-only && \
     yum -y install cmake make gcc git unzip tarantool tarantool-devel cartridge-cli && \
     yum clean all
@@ -11,9 +11,9 @@ RUN groupadd -g $TARANTOOL_SERVER_GID $TARANTOOL_SERVER_GROUP && \
     useradd -u $TARANTOOL_SERVER_UID -g $TARANTOOL_SERVER_GID -m -s /bin/bash $TARANTOOL_SERVER_USER \
     || true
 USER $TARANTOOL_SERVER_USER:$TARANTOOL_SERVER_GROUP
-RUN env && cartridge version
+RUN cartridge version
 
 FROM tarantool-base AS cartridge-base
-ENV TARANTOOL_WORKDIR="/app"
+ARG TARANTOOL_WORKDIR="/app"
 WORKDIR $TARANTOOL_WORKDIR
-CMD env && cartridge build && cartridge start
+CMD cartridge build && cartridge start

--- a/src/main/resources/Dockerfile
+++ b/src/main/resources/Dockerfile
@@ -11,9 +11,9 @@ RUN groupadd -g $TARANTOOL_SERVER_GID $TARANTOOL_SERVER_GROUP && \
     useradd -u $TARANTOOL_SERVER_UID -g $TARANTOOL_SERVER_GID -m -s /bin/bash $TARANTOOL_SERVER_USER \
     || true
 USER $TARANTOOL_SERVER_USER:$TARANTOOL_SERVER_GROUP
-RUN ls -l /etc/yum.repos.d/ && cartridge version
+RUN env && cartridge version
 
 FROM tarantool-base AS cartridge-base
 ENV TARANTOOL_WORKDIR="/app"
 WORKDIR $TARANTOOL_WORKDIR
-CMD cartridge build && cartridge start
+CMD env && cartridge build && cartridge start

--- a/src/main/resources/Dockerfile
+++ b/src/main/resources/Dockerfile
@@ -1,0 +1,19 @@
+FROM centos:7 AS tarantool-base
+ENV TARANTOOL_VERSION=2.4
+ENV TARANTOOL_SERVER_USER="tarantool"
+ENV TARANTOOL_SERVER_UID=1000
+ENV TARANTOOL_SERVER_GROUP="tarantool"
+ENV TARANTOOL_SERVER_GID=1000
+RUN curl -L https://tarantool.io/installer.sh | VER=$TARANTOOL_VERSION /bin/bash -s -- --repo-only && \
+    yum -y install cmake make gcc git unzip tarantool tarantool-devel cartridge-cli && \
+    yum clean all
+RUN groupadd -g $TARANTOOL_SERVER_GID $TARANTOOL_SERVER_GROUP && \
+    useradd -u $TARANTOOL_SERVER_UID -g $TARANTOOL_SERVER_GID -m -s /bin/bash $TARANTOOL_SERVER_USER \
+    || true
+USER $TARANTOOL_SERVER_USER:$TARANTOOL_SERVER_GROUP
+RUN ls -l /etc/yum.repos.d/ && cartridge version
+
+FROM tarantool-base AS cartridge-base
+ENV TARANTOOL_WORKDIR="/app"
+WORKDIR $TARANTOOL_WORKDIR
+CMD cartridge build && cartridge start

--- a/src/test/java/org/testcontainers/containers/TarantoolCartridgeStaticContainerTest.java
+++ b/src/test/java/org/testcontainers/containers/TarantoolCartridgeStaticContainerTest.java
@@ -1,6 +1,8 @@
 package org.testcontainers.containers;
 
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -16,14 +18,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class TarantoolCartridgeStaticContainerTest {
 
     @Container
-    private static final TarantoolCartridgeContainer container =
-            new TarantoolCartridgeContainer(
+    private static final TarantoolCartridgeContainer<?> container =
+            new TarantoolCartridgeContainer<>(
                     TarantoolContainer.DEFAULT_TARANTOOL_BASE_IMAGE,
                     "testcontainers-java-tarantool:test",
                     "cartridge/instances.yml",
                     "cartridge/topology.lua")
                     .withDirectoryBinding("cartridge")
-                    .cleanUpDirectory("cartridge/tmp");
+                    .cleanUpDirectory("cartridge/tmp")
+                    .withLogConsumer(new Slf4jLogConsumer(
+                            LoggerFactory.getLogger(TarantoolCartridgeStaticContainerTest.class)));
 
 
     @Test
@@ -31,8 +35,8 @@ public class TarantoolCartridgeStaticContainerTest {
         container.executeCommand(
                 "return profile_replace(...)", Arrays.asList(1, "Ivanov Ivan Ivanovich", 33, 100500)).get();
 
-        List<Object> result = container.executeCommand("return profile_get(...)", 1).get();
+        List<?> result = container.executeCommand("return profile_get(...)", 1).get();
         assertEquals(1, result.size());
-        assertEquals(33, ((List<Object>) result.get(0)).get(3));
+        assertEquals(33, ((List<?>) result.get(0)).get(3));
     }
 }

--- a/src/test/java/org/testcontainers/containers/TarantoolCartridgeStaticContainerTest.java
+++ b/src/test/java/org/testcontainers/containers/TarantoolCartridgeStaticContainerTest.java
@@ -18,17 +18,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class TarantoolCartridgeStaticContainerTest {
 
     @Container
-    private static final TarantoolCartridgeContainer<?> container =
-            new TarantoolCartridgeContainer<>(
-                    TarantoolContainer.DEFAULT_TARANTOOL_BASE_IMAGE,
+    private static final TarantoolCartridgeContainer container =
+            new TarantoolCartridgeContainer(
+                    "Dockerfile",
                     "testcontainers-java-tarantool:test",
                     "cartridge/instances.yml",
                     "cartridge/topology.lua")
                     .withDirectoryBinding("cartridge")
-                    .cleanUpDirectory("cartridge/tmp")
                     .withLogConsumer(new Slf4jLogConsumer(
                             LoggerFactory.getLogger(TarantoolCartridgeStaticContainerTest.class)));
-
 
     @Test
     public void testContainerWithParameters() throws Exception {

--- a/src/test/java/org/testcontainers/containers/TarantoolContainerTest.java
+++ b/src/test/java/org/testcontainers/containers/TarantoolContainerTest.java
@@ -13,7 +13,7 @@ class TarantoolContainerTest {
 
     @Test
     public void testExecuteScript() throws Exception {
-        try (TarantoolContainer<?> container = new TarantoolContainer<>()) {
+        try (TarantoolContainer container = new TarantoolContainer()) {
             container.start();
 
             container.executeScript("org/testcontainers/containers/test.lua").get();
@@ -26,7 +26,7 @@ class TarantoolContainerTest {
     @Test
     public void testContainerWithParameters() throws Exception {
         int memory = 256 * 1024 * 1024;
-        try (TarantoolContainer<?> container = new TarantoolContainer<>()
+        try (TarantoolContainer container = new TarantoolContainer()
                 .withDirectoryBinding("io/tarantool")
                 .withScriptFileName("custom.lua")
                 .withUsername("uuuser")

--- a/src/test/java/org/testcontainers/containers/TarantoolContainerTest.java
+++ b/src/test/java/org/testcontainers/containers/TarantoolContainerTest.java
@@ -13,11 +13,11 @@ class TarantoolContainerTest {
 
     @Test
     public void testExecuteScript() throws Exception {
-        try (TarantoolContainer container = new TarantoolContainer()) {
+        try (TarantoolContainer<?> container = new TarantoolContainer<>()) {
             container.start();
 
             container.executeScript("org/testcontainers/containers/test.lua").get();
-            List<Object> result = container.executeCommand("return user_function_no_param()").get();
+            List<?> result = container.executeCommand("return user_function_no_param()").get();
             assertEquals(1, result.size());
             assertEquals(5, result.get(0));
         }
@@ -26,7 +26,7 @@ class TarantoolContainerTest {
     @Test
     public void testContainerWithParameters() throws Exception {
         int memory = 256 * 1024 * 1024;
-        try (TarantoolContainer container = new TarantoolContainer()
+        try (TarantoolContainer<?> container = new TarantoolContainer<>()
                 .withDirectoryBinding("io/tarantool")
                 .withScriptFileName("custom.lua")
                 .withUsername("uuuser")
@@ -35,7 +35,7 @@ class TarantoolContainerTest {
                 .withLogLevel(TarantoolLogLevel.INFO)) {
             container.start();
 
-            List<Object> result = container.executeCommand("return box.cfg.memtx_memory").get();
+            List<?> result = container.executeCommand("return box.cfg.memtx_memory").get();
             assertEquals(1, result.size());
             assertEquals(memory, result.get(0));
 

--- a/src/test/java/org/testcontainers/containers/TarantoolStaticContainerTest.java
+++ b/src/test/java/org/testcontainers/containers/TarantoolStaticContainerTest.java
@@ -15,18 +15,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class TarantoolStaticContainerTest {
 
     @Container
-    private static TarantoolContainer container = new TarantoolContainer();
+    private static TarantoolContainer<?> container = new TarantoolContainer<>();
 
     @Test
     public void testExecuteCommand() throws Exception {
-        List<Object> result = container.executeCommand("return 1, 2").get();
+        List<?> result = container.executeCommand("return 1, 2").get();
         assertEquals(2, result.size());
         assertEquals(1, result.get(0));
     }
 
     @Test
     public void testExecuteCommandWithArguments() throws Exception {
-        List<Object> result = container.executeCommand(
+        List<?> result = container.executeCommand(
                 "return require('fun').iter({...}):reduce(function(x, acc) return acc+x end, 0)",
                 1, 2, 3)
                 .get();
@@ -37,7 +37,7 @@ public class TarantoolStaticContainerTest {
     @Test
     public void testSetLogLevel() throws Exception {
         container.withLogLevel(TarantoolLogLevel.INFO);
-        List<Object> result = container.executeCommand("return box.cfg.log_level").get();
+        List<?> result = container.executeCommand("return box.cfg.log_level").get();
         assertEquals(1, result.size());
         assertEquals(5, result.get(0));
     }
@@ -46,7 +46,7 @@ public class TarantoolStaticContainerTest {
     public void testSetMemtxMemory() throws Exception {
         int memory = 256 * 1024 * 1024;
         container.withMemtxMemory(memory);
-        List<Object> result = container.executeCommand("return box.cfg.memtx_memory").get();
+        List<?> result = container.executeCommand("return box.cfg.memtx_memory").get();
         assertEquals(1, result.size());
         assertEquals(memory, result.get(0));
     }

--- a/src/test/java/org/testcontainers/containers/TarantoolStaticContainerTest.java
+++ b/src/test/java/org/testcontainers/containers/TarantoolStaticContainerTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class TarantoolStaticContainerTest {
 
     @Container
-    private static TarantoolContainer<?> container = new TarantoolContainer<>();
+    private static TarantoolContainer container = new TarantoolContainer();
 
     @Test
     public void testExecuteCommand() throws Exception {


### PR DESCRIPTION
  - Update to driver 0.3.3 (get rid of the outdated 0.1.1 version)
  - Move to a Dockerfile instead of a runtime build image which caused long build times (affects https://github.com/tarantool/cartridge-java/issues/25)
  - Change the constructor signatures for TarantoolCartridgeContainer, add new getters
  
  Fixes #3 