### PR TITLE
Use /tmp directory in Docker container for Cartridge run and data directories

### DIFF
--- a/src/main/java/org/testcontainers/containers/TarantoolCartridgeContainer.java
+++ b/src/main/java/org/testcontainers/containers/TarantoolCartridgeContainer.java
@@ -93,6 +93,8 @@ public class TarantoolCartridgeContainer extends GenericContainer<TarantoolCartr
     private static final String ENV_TARANTOOL_SERVER_GROUP="TARANTOOL_SERVER_GROUP";
     private static final String ENV_TARANTOOL_SERVER_GID="TARANTOOL_SERVER_GID";
     private static final String ENV_TARANTOOL_WORKDIR="TARANTOOL_WORKDIR";
+    private static final String ENV_TARANTOOL_RUNDIR="TARANTOOL_RUNDIR";
+    private static final String ENV_TARANTOOL_DATADIR="TARANTOOL_DATADIR";
 
     private String routerHost = ROUTER_HOST;
     private int routerPort = ROUTER_PORT;
@@ -161,7 +163,9 @@ public class TarantoolCartridgeContainer extends GenericContainer<TarantoolCartr
             .withBuildArg(ENV_TARANTOOL_SERVER_UID, System.getenv(ENV_TARANTOOL_SERVER_UID))
             .withBuildArg(ENV_TARANTOOL_SERVER_GROUP, System.getenv(ENV_TARANTOOL_SERVER_GROUP))
             .withBuildArg(ENV_TARANTOOL_SERVER_GID, System.getenv(ENV_TARANTOOL_SERVER_GID))
-            .withBuildArg(ENV_TARANTOOL_WORKDIR, System.getenv(ENV_TARANTOOL_WORKDIR));
+            .withBuildArg(ENV_TARANTOOL_WORKDIR, System.getenv(ENV_TARANTOOL_WORKDIR))
+            .withBuildArg(ENV_TARANTOOL_RUNDIR, System.getenv(ENV_TARANTOOL_RUNDIR))
+            .withBuildArg(ENV_TARANTOOL_DATADIR, System.getenv(ENV_TARANTOOL_DATADIR));
     }
 
     private static ImageFromDockerfile buildImage() {

--- a/src/main/resources/Dockerfile
+++ b/src/main/resources/Dockerfile
@@ -4,6 +4,12 @@ ARG TARANTOOL_SERVER_USER="tarantool"
 ARG TARANTOOL_SERVER_UID=1000
 ARG TARANTOOL_SERVER_GROUP="tarantool"
 ARG TARANTOOL_SERVER_GID=1000
+ARG TARANTOOL_WORKDIR="/app"
+ARG TARANTOOL_RUNDIR="/tmp/run"
+ARG TARANTOOL_DATADIR="/tmp/data"
+ENV TARANTOOL_WORKDIR=$TARANTOOL_WORKDIR
+ENV TARANTOOL_RUNDIR=$TARANTOOL_RUNDIR
+ENV TARANTOOL_DATADIR=$TARANTOOL_DATADIR
 RUN curl -L https://tarantool.io/installer.sh | VER=$TARANTOOL_VERSION /bin/bash -s -- --repo-only && \
     yum -y install cmake make gcc git unzip tarantool tarantool-devel cartridge-cli && \
     yum clean all
@@ -14,6 +20,5 @@ USER $TARANTOOL_SERVER_USER:$TARANTOOL_SERVER_GROUP
 RUN cartridge version
 
 FROM tarantool-base AS cartridge-base
-ARG TARANTOOL_WORKDIR="/app"
 WORKDIR $TARANTOOL_WORKDIR
-CMD cartridge build && cartridge start
+CMD cartridge build && cartridge start --run-dir=$TARANTOOL_RUNDIR --data-dir=$TARANTOOL_DATADIR

--- a/src/test/resources/cartridge/.cartridge.yml
+++ b/src/test/resources/cartridge/.cartridge.yml
@@ -1,3 +1,2 @@
 ---
-run_dir: 'tmp'
 cfg: instances.yml


### PR DESCRIPTION
Use internal /tmp directory in the container instead of local tmp directory by default.

Helps to avoid the error "failed to create server unix/:/app/tmp/run/testapp.second-router.control: Input/output error" when starting Cartridge from some nested directory which causes a very long socket path.

Affects #7 