### PR TITLE
Added clientBuilder to TarantoolContainer constructor

### DIFF
--- a/src/main/java/org/testcontainers/containers/TarantoolContainer.java
+++ b/src/main/java/org/testcontainers/containers/TarantoolContainer.java
@@ -1,6 +1,7 @@
 package org.testcontainers.containers;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
+import io.tarantool.driver.api.TarantoolClientBuilder;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.net.URL;
@@ -47,23 +48,86 @@ public class TarantoolContainer extends GenericContainer<TarantoolContainer>
 
     private final TarantoolContainerClientHelper clientHelper;
 
+    /**
+     * Constructor for {@link TarantoolContainer}
+     */
     public TarantoolContainer() {
         this(String.format("%s:%s", TARANTOOL_IMAGE, DEFAULT_IMAGE_VERSION));
     }
 
+    /**
+     * Constructor for {@link TarantoolContainer}
+     *
+     * @param clientBuilder client builder with custom client settings for setting up container
+     */
+    public TarantoolContainer(TarantoolClientBuilder clientBuilder) {
+        this(String.format("%s:%s", TARANTOOL_IMAGE, DEFAULT_IMAGE_VERSION), clientBuilder);
+    }
+
+    /**
+     * Constructor for {@link TarantoolContainer}
+     *
+     * @param dockerImageName docker image name for container creating
+     */
     public TarantoolContainer(String dockerImageName) {
         super(dockerImageName);
         clientHelper = new TarantoolContainerClientHelper(this);
     }
 
+    /**
+     * Constructor for {@link TarantoolContainer}
+     *
+     * @param dockerImageName docker image name for container creating
+     * @param clientBuilder   client builder with custom client settings for setting up container
+     */
+    public TarantoolContainer(String dockerImageName,
+                              TarantoolClientBuilder clientBuilder) {
+        super(dockerImageName);
+        clientHelper = new TarantoolContainerClientHelper(this, clientBuilder);
+    }
+
+    /**
+     * Constructor for {@link TarantoolContainer}
+     *
+     * @param tarantoolImageParams params for cached image creating
+     */
     public TarantoolContainer(TarantoolImageParams tarantoolImageParams) {
         super(TarantoolContainerImageHelper.getImage(tarantoolImageParams));
         clientHelper = new TarantoolContainerClientHelper(this);
     }
 
+    /**
+     * Constructor for {@link TarantoolContainer}
+     *
+     * @param tarantoolImageParams params for cached image creating
+     * @param clientBuilder        client builder with custom client settings for setting up container
+     */
+    public TarantoolContainer(TarantoolImageParams tarantoolImageParams,
+                              TarantoolClientBuilder clientBuilder) {
+        super(TarantoolContainerImageHelper.getImage(tarantoolImageParams));
+        clientHelper = new TarantoolContainerClientHelper(this, clientBuilder);
+    }
+
+    /**
+     * Constructor for {@link TarantoolContainer}
+     *
+     * @param image future with image name
+     */
     public TarantoolContainer(Future<String> image) {
         super(image);
         clientHelper = new TarantoolContainerClientHelper(this);
+    }
+
+    /**
+     * Constructor for {@link TarantoolContainer}
+     *
+     * @param image         future with image name
+     * @param clientBuilder client builder with custom client settings for setting up container
+     */
+    public TarantoolContainer(Future<String> image,
+                              TarantoolClientBuilder clientBuilder) {
+        super(image);
+        clientHelper = new TarantoolContainerClientHelper(this, clientBuilder);
     }
 
     /**

--- a/src/main/java/org/testcontainers/containers/TarantoolContainerClientHelper.java
+++ b/src/main/java/org/testcontainers/containers/TarantoolContainerClientHelper.java
@@ -1,6 +1,7 @@
 package org.testcontainers.containers;
 
 import io.tarantool.driver.api.TarantoolClient;
+import io.tarantool.driver.api.TarantoolClientBuilder;
 import io.tarantool.driver.api.TarantoolClientFactory;
 import io.tarantool.driver.api.TarantoolResult;
 import io.tarantool.driver.api.retry.TarantoolRequestRetryPolicies;
@@ -27,13 +28,21 @@ public final class TarantoolContainerClientHelper {
     private final TarantoolContainerOperations<? extends Container<?>> container;
     private final AtomicReference<TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>>> clientHolder =
             new AtomicReference<>();
+    private final TarantoolClientBuilder clientBuilder;
 
     TarantoolContainerClientHelper(TarantoolContainerOperations<? extends Container<?>> container) {
         this.container = container;
+        this.clientBuilder = TarantoolClientFactory.createClient();
+    }
+
+    TarantoolContainerClientHelper(TarantoolContainerOperations<? extends Container<?>> container,
+                                   TarantoolClientBuilder clientBuilder) {
+        this.container = container;
+        this.clientBuilder = clientBuilder;
     }
 
     private TarantoolClient<TarantoolTuple, TarantoolResult<TarantoolTuple>> createClient() {
-        return TarantoolClientFactory.createClient()
+        return clientBuilder
                 .withCredentials(container.getUsername(), container.getPassword())
                 .withAddress(container.getHost(), container.getPort())
                 .withRequestTimeout(5000)

--- a/src/main/java/org/testcontainers/containers/TarantoolContainerClientHelper.java
+++ b/src/main/java/org/testcontainers/containers/TarantoolContainerClientHelper.java
@@ -32,7 +32,11 @@ public final class TarantoolContainerClientHelper {
 
     TarantoolContainerClientHelper(TarantoolContainerOperations<? extends Container<?>> container) {
         this.container = container;
-        this.clientBuilder = TarantoolClientFactory.createClient();
+        this.clientBuilder = TarantoolClientFactory.createClient()
+                .withRequestTimeout(5000)
+                .withRetryingByNumberOfAttempts(15,
+                        TarantoolRequestRetryPolicies.retryNetworkErrors(),
+                        b -> b.withDelay(100));
     }
 
     TarantoolContainerClientHelper(TarantoolContainerOperations<? extends Container<?>> container,
@@ -45,10 +49,6 @@ public final class TarantoolContainerClientHelper {
         return clientBuilder
                 .withCredentials(container.getUsername(), container.getPassword())
                 .withAddress(container.getHost(), container.getPort())
-                .withRequestTimeout(5000)
-                .withRetryingByNumberOfAttempts(15,
-                        TarantoolRequestRetryPolicies.retryNetworkErrors(),
-                        b -> b.withDelay(100))
                 .build();
     }
 


### PR DESCRIPTION
Added clientBuilder to TarantoolContainer constructor.
We can't use ssl container without customizable clientBuilder.
Or any custom users settings for managing container settings.
