### PR TITLE
Bump dependencies

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+<!-- What has been done? Why? What problem is being solved? -->
+
+
+I haven't forgotten about:
+- [ ] Tests
+- [ ] Changelog
+- [ ] Documentation
+- [ ] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
+- [ ] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)
+
+Related issues:
+<!-- Needed for #123 -->
+<!-- See also #456, #789 -->
+<!-- Part of #123 -->
+<!-- Closes #456 -->

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+**/.DS_Store
 target/
 .idea/
 *.iml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.5.1] - 2022-10-28
+- Bump cartridge-java to 0.9.1
+- Bump testcontainers to 1.17.4
+
 ## [0.5.0] - 2022-05-18
 - Added ability to configure cluster from yaml (#40)
 - Added migrations example in tests (#42)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add the Maven dependency:
 <dependency>
   <groupId>io.tarantool</groupId>
   <artifactId>testcontainers-java-tarantool</artifactId>
-  <version>0.5.0</version>
+  <version>0.5.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
     </scm>
 
     <properties>
-        <driver.version>0.7.0</driver.version>
-        <testcontainers.version>1.16.2</testcontainers.version>
+        <driver.version>0.9.1</driver.version>
+        <testcontainers.version>1.17.4</testcontainers.version>
         <snakeyaml.version>1.26</snakeyaml.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
<!-- What has been done? Why? What problem is being solved? -->
- Bump cartridge-java to 0.9.1
- Bump testcontainers to 1.17.4

I haven't forgotten about:
- [x] Tests
- [x] Changelog
- [x] Documentation
- [x] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
Closes #52 
<!-- Needed for #123 -->
<!-- See also #456, #789 -->
<!-- Part of #123 -->
<!-- Closes #456 -->