### PR TITLE
Use add exposed ports instead of set exposed ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Fix problem if topology isn't applied correctly
 - Bump testcontainers to 1.18.0
 - Move rocks building in build phase
-- Use add exposed ports instead of set exposed ports
+- Use "addExposedPorts" instead of "withExposedPorts"
 
 ## [0.5.4] - 2023-03-31
 - Use tarantool image as base instead of centos in cartridge container

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix problem if topology isn't applied correctly
 - Bump testcontainers to 1.18.0
 - Move rocks building in build phase
+- Use add exposed ports instead of set exposed ports
 
 ## [0.5.4] - 2023-03-31
 - Use tarantool image as base instead of centos in cartridge container

--- a/src/main/java/org/testcontainers/containers/TarantoolCartridgeContainer.java
+++ b/src/main/java/org/testcontainers/containers/TarantoolCartridgeContainer.java
@@ -5,6 +5,7 @@ import io.tarantool.driver.exceptions.TarantoolConnectionException;
 
 import org.testcontainers.containers.exceptions.CartridgeTopologyException;
 import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.shaded.org.apache.commons.lang3.ArrayUtils;
 
 import java.net.URL;
 import java.util.Arrays;
@@ -463,7 +464,7 @@ public class TarantoolCartridgeContainer extends GenericContainer<TarantoolCartr
                 addFixedExposedPort(port, port);
             }
         } else {
-            withExposedPorts(instanceFileParser.getExposablePorts());
+            addExposedPorts(ArrayUtils.toPrimitive(instanceFileParser.getExposablePorts()));
         }
     }
 

--- a/src/main/java/org/testcontainers/containers/TarantoolCartridgeContainer.java
+++ b/src/main/java/org/testcontainers/containers/TarantoolCartridgeContainer.java
@@ -217,6 +217,16 @@ public class TarantoolCartridgeContainer extends GenericContainer<TarantoolCartr
         return image;
     }
 
+    public TarantoolCartridgeContainer withFixedExposedPort(int hostPort, int containerPort) {
+        super.addFixedExposedPort(hostPort, containerPort);
+        return this;
+    }
+
+    public TarantoolCartridgeContainer withExposedPort(Integer port) {
+        super.addExposedPort(port);
+        return this;
+    }
+
     private static Map<String, String> mergeBuildArguments(Map<String, String> buildArgs) {
         Map<String, String> args = new HashMap<>(buildArgs);
 

--- a/src/main/java/org/testcontainers/containers/TarantoolContainer.java
+++ b/src/main/java/org/testcontainers/containers/TarantoolContainer.java
@@ -166,6 +166,16 @@ public class TarantoolContainer extends GenericContainer<TarantoolContainer>
         return this;
     }
 
+    public TarantoolContainer withFixedExposedPort(int hostPort, int containerPort) {
+        super.addFixedExposedPort(hostPort, containerPort);
+        return this;
+    }
+
+    public TarantoolContainer withExposedPort(Integer port) {
+        super.addExposedPort(port);
+        return this;
+    }
+
     @Override
     public String getHost() {
         return host;

--- a/src/main/java/org/testcontainers/containers/TarantoolContainer.java
+++ b/src/main/java/org/testcontainers/containers/TarantoolContainer.java
@@ -349,7 +349,7 @@ public class TarantoolContainer extends GenericContainer<TarantoolContainer>
         if (useFixedPorts) {
             addFixedExposedPort(port, port);
         } else {
-            withExposedPorts(port);
+            addExposedPorts(port);
         }
 
         withCommand("tarantool", normalizePath(


### PR DESCRIPTION
It's needed when you want to use not only default ports. For example it's usefull when you use metrics for TarantoolContainer.

<!-- What has been done? Why? What problem is being solved? -->


I haven't forgotten about:
- [ ] Tests
- [x] Changelog
- [ ] Documentation
- [x] Commit messages comply with the [guideline](https://www.tarantool.io/en/doc/latest/dev_guide/developer_guidelines/#how-to-write-a-commit-message)
- [x] Cleanup the code for review. See [checklist](https://github.com/tarantool/cartridge-java/blob/master/docs/review-checklist.md)

Related issues:
<!-- Needed for #123 -->
<!-- See also #456, #789 -->
<!-- Part of #123 -->
Closes #65